### PR TITLE
write-pwm

### DIFF
--- a/src/RCADER/declarations.h
+++ b/src/RCADER/declarations.h
@@ -57,8 +57,7 @@ void correct_for_dinuc( s_seq *seqs[], int num_seqs );
 void optimize_PWMs( s_seq *seqs[], int num_seqs, s_motif *motifs[], int num_motifs );
 
 bool write_scores( ofstream &ofs, s_seq *seqs[], int num_seqs, s_motif *motifs[], int num_motifs );
-bool write_PFMs( ofstream &ofs, s_motif *motifs[], int num_motifs, const char *experiment_name, bool opt_only );
-void write_opt_MEME( ofstream &ofs, s_motif *motif, const char *experiment_name );
+bool write_PWMs( ofstream &ofs, s_motif *motifs[], int num_motifs, const char *experiment_name, bool opt_only );
 void write_report( ofstream &ofs, s_motif *motifs[], int num_motifs, const char *experiment_name );
 void write_graphics( ofstream &ofs, s_motif *motifs[], int num_motifs );
 

--- a/src/RCADER/main.cpp
+++ b/src/RCADER/main.cpp
@@ -73,8 +73,8 @@ int main( int argc, char* argv[] )
 
 	//******************* open output
 
-	ofstream ofs_PFM;
-	if( !open_output( ofs_PFM, __output_file, ".PFM.txt" ) )
+	ofstream ofs_PWM;
+	if( !open_output( ofs_PWM, __output_file, ".PWM.txt" ) )
 		return 1;
 
 	//ofstream ofs_opt_PFM;
@@ -155,7 +155,7 @@ int main( int argc, char* argv[] )
 		return 1;
 
 	// write all optimized PFMs
-	if( !write_PFMs( ofs_PFM, motifs, num_motifs, __experiment, true ) )
+	if( !write_PWMs( ofs_PWM, motifs, num_motifs, __experiment, true ) )
 		return 1;
 
 	// write the optimized PFM for the best-scoring motif

--- a/src/RCADER/write.cpp
+++ b/src/RCADER/write.cpp
@@ -89,7 +89,7 @@ bool write_scores(
 
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-bool write_PFMs(
+bool write_PWMs(
 	ofstream &ofs,
 	s_motif *motifs[],
 	int num_motifs,
@@ -122,7 +122,7 @@ bool write_PFMs(
 				{
 					ofs << j+1;
 					for( n = 0; n < NUM_N_LETTERS; n ++ )
-						ofs << char(9) << pow( 10, motifs[ i ] ->PWM[ n ][ j ] ) / NUM_N_LETTERS;
+						ofs << char(9) << motifs[ i ] ->PWM[ n ][ j ];
 					ofs << endl;
 				}
 
@@ -149,7 +149,7 @@ bool write_PFMs(
 			{
 				ofs << j+1;
 				for( n = 0; n < NUM_N_LETTERS; n ++ )
-					ofs << char(9) << pow( 10, motifs[ i ] ->opt_PWM[ n ][ j ] ) / NUM_N_LETTERS;
+					ofs << char(9) << motifs[ i ] ->opt_PWM[ n ][ j ];
 				ofs << endl;
 			}
 	
@@ -157,46 +157,6 @@ bool write_PFMs(
 		}
 	
 	return true;
-}
-
-
-///////////////////////////////////////////////////////////////////////////////////////////
-void write_opt_MEME(
-	ofstream &ofs,
-	s_motif *motif,
-	const char *experiment_name )
-{
-	if( !motif ->PWM_optimized )
-		return; // if this motif is not optimized, do not write it
-	
-	// write the PWM for this motif in a format that is recognized by the MEME suite
-	
-	ofs << "MEME version 4" << endl
-		<< endl
-		<< "ALPHABET= ACGT" << endl
-		<< endl
-		<< "strands: + -" << endl
-		<< endl;
-	
-	ofs << "MOTIF " << motif ->name << "|opt" << experiment_name << endl
-		<< "letter-probability matrix: alength= " << NUM_N_LETTERS
-			<< " w= " << motif ->PWM_width
-			<< " nsites= 10000" << endl;
-
-	int i;
-	for( i = 0; i < motif ->PWM_width; i ++ )
-	{
-		int n;
-		for( n = 0; n < NUM_N_LETTERS; n ++ )
-		{
-			if( n > 0 )
-				ofs << char(9);
-			ofs << pow( 10, motif ->opt_PWM[ n ][ i ] ) / NUM_N_LETTERS;
-		}
-		ofs << endl;
-	}
-			
-	ofs << endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
RCADER now writes the PWMs instead of PFMs. This makes more sense given
that RCADER provides the option for “not” normalizing the PWMs (using
negative) -enf , in which case conversion to PFMs is not appropriate.